### PR TITLE
Makes it possible to actually change the rules URL

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -29,16 +29,14 @@
 	set name = "rules"
 	set desc = "Show Server Rules."
 	set hidden = 1
-//	var/rulesurl = CONFIG_GET(string/rulesurl)
-	switch(alert("Would you like to see the rules?", null, "View here", "Cancel"))
-/*		if("Discord (external link)")
-			if(!rulesurl)
-				to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
-				return
-			src << link(rulesurl)*/
-		if("View here")
-			src << browse('html/rules.html', "window=changes")
-
+	var/rulesurl = CONFIG_GET(string/rulesurl)
+	if(rulesurl)
+		if(alert("This will open the rules page in your browser. Are you sure?",,"Yes","No")!="Yes")
+			return
+		src << link(rulesurl)
+	else
+		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
+	return
 
 /client/verb/github()
 	set name = "github"


### PR DESCRIPTION
Title. Does exactly as it says on the tin.

## Changelog
:cl: Bhijn
tweak: The rules button no longer opens a hardcoded popup, but rather, points to whatever the rules url is set to in the config
/:cl:
