### PR TITLE
Vehicle fuel framework + ATVs use fuel now

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -178,3 +178,11 @@
 	materials = list(MAT_BIOMASS = 5)
 	build_path = /obj/item/stack/tile/carpet
 	category = list("initial","Misc")
+
+/datum/design/biodiesel
+	name = "Biodiesel"
+	id = "biodiesel"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 100)
+	make_reagents = list("biodiesel" = 10)
+	category = list("initial","Misc")

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -25,9 +25,14 @@
 	var/list/autogrant_actions_controller	//assoc list "[bitflag]" = list(typepaths)
 	var/list/mob/occupant_actions			//assoc list mob = list(type = action datum assigned to mob)
 	var/obj/vehicle/trailer
+	var/fueltype //what fuel do we use if we use fuel. if we don't use fuel this is null.
+	var/fueluse //how much fuel is consumed on a move proc
+	var/tanksize //size of the fuel tank
 
 /obj/vehicle/Initialize(mapload)
 	. = ..()
+	if(fueltype && fueluse && tanksize)
+		create_reagents(tanksize) //fuel tank
 	occupants = list()
 	autogrant_actions_passenger = list()
 	autogrant_actions_controller = list()
@@ -106,9 +111,15 @@
 		return FALSE
 	if(!default_driver_move)
 		return
+	if(fueltype && fueluse)
+		if(reagents.get_reagent_amount(fueltype) < fueluse)
+			to_chat(user, "<span class='warning'>[src]'s engine sputters!</span>")
+			return
 	vehicle_move(direction)
 
 /obj/vehicle/proc/vehicle_move(direction)
+	if(fueltype && fueluse)
+		reagents.remove_reagent("fueltype", fueluse)
 	if(lastmove + movedelay > world.time)
 		return FALSE
 	lastmove = world.time

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -5,6 +5,9 @@
 	icon_state = "atv"
 	key_type = /obj/item/key
 	var/static/mutable_appearance/atvcover
+	fueltype = "biodiesel"
+	fueluse = 0.25
+	tanksize = 100 //400 tiles movement on a single tank. 1k biomass needed to fill the tank.
 
 /obj/vehicle/ridden/atv/Initialize()
 	. = ..()


### PR DESCRIPTION

## Description
A framework for a reagent fuel system for vehicles. I might add a cell using framework but that's out of scope for now. 

Adds Biodiesel to the biogenerator. It costs 100 biomass > 10 biodiesel. 

ATVs use biodiesel to move. 1 biodiesel for 4 tiles, at a fuel capacity of 100.

## Motivation and Context
I wanted to give the factions vehicles as moving around is kinda painful, but movement speed is one of the strongest stats in combat so making it cost resources is a fair trade IMO.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Framework for fuel consuming vehicles.
balance: ATVs now use biodiesel.
/:cl:
