### PR TITLE
Fixes NPC Factions: 2nd Pass

### DIFF
--- a/code/modules/fallout/mob/simple_animal/mobs/Securitron.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/Securitron.dm
@@ -21,7 +21,7 @@
 	health = 300
 	del_on_death = 1
 	healable = 0
-	faction = list("neutral", "city", "ncr")
+	faction = list("neutral", "city", "ncr") // This should be "NCR" but a number of POIs use thse as enemies.
 	emote_hear = list("Beeps.")
 	speak = list("Stop Right There Criminal.")
 	death_sound = 'sound/f13npc/robot_death.ogg'

--- a/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
@@ -25,7 +25,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/vault)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
-	faction = list("vault", "city")
+	faction = list("Vault", "city")
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1
@@ -277,7 +277,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/bs)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
-	faction = list("BOS", "city", "vault")
+	faction = list("BOS", "city", "Vault")
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1
@@ -371,7 +371,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/ncr)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
-	faction = list("NCR", "city", "followers", "vault")
+	faction = list("NCR", "city", "followers", "Vault")
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1

--- a/code/modules/mob/living/simple_animal/hostile/chinese.dm
+++ b/code/modules/mob/living/simple_animal/hostile/chinese.dm
@@ -39,6 +39,7 @@
 	minimum_distance = 6
 	projectiletype = /obj/item/projectile/bullet/c9mm
 	projectilesound =  'sound/f13weapons/ninemil.ogg'
+	casingtype = /obj/item/ammo_casing/c9mm
 
 /mob/living/simple_animal/hostile/chinese/ranged/assault
 	name = "chinese remnant assault soldier"
@@ -50,6 +51,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/chineseremnant/assault, /obj/item/gun/ballistic/automatic/type93, /obj/item/ammo_box/magazine/m556/rifle/assault)
 	projectiletype = /obj/item/projectile/bullet/a556/ap
 	projectilesound = 'sound/f13weapons/assaultrifle_fire.ogg'
+	casingtype = /obj/item/ammo_casing/a556
 
 /mob/living/simple_animal/hostile/chinese/ranged/assault/Aggro()
 	..()


### PR DESCRIPTION
Realized I missed some of the vault tech NPCs because 'vault' isn't 'Vault

## Description
Adds Vault faction tag (instead of 'vault') to Vault dweller NPCs to make them stop shooting Vault players.

## Motivation and Context
Shooting friendlies is bad.

## How Has This Been Tested?
Compiles.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
fix: Gave vault dweller NPCs their appropriate faction tags.
fix: Chinese ghouls no longer use caseless rounds
:/cl:
